### PR TITLE
Add Cursor-compatible rules for interface-design skill system

### DIFF
--- a/.cursor/rules/interface-design-audit.mdc
+++ b/.cursor/rules/interface-design-audit.mdc
@@ -1,0 +1,67 @@
+---
+description: Use when user asks to audit or check their code against the design system for spacing, depth, color, and pattern violations.
+globs:
+alwaysApply: false
+---
+
+# Design System Audit
+
+Check existing code against your design system.
+
+## Usage
+
+User says "audit", "audit <path>", or "check against system".
+
+## What to Check
+
+**If `.interface-design/system.md` exists:**
+
+1. **Spacing violations**
+   - Find spacing values not on defined grid
+   - Example: 17px when base is 4px
+
+2. **Depth violations**
+   - Borders-only system → flag shadows
+   - Subtle system → flag layered shadows
+   - Allow ring shadows (0 0 0 1px)
+
+3. **Color violations**
+   - If palette defined → flag colors not in palette
+   - Allow semantic grays
+
+4. **Pattern drift**
+   - Find buttons not matching Button pattern
+   - Find cards not matching Card pattern
+
+**Report format:**
+```
+Audit Results: src/components/
+
+Violations:
+  Button.tsx:12 - Height 38px (pattern: 36px)
+  Card.tsx:8 - Shadow used (system: borders-only)
+  Input.tsx:20 - Spacing 14px (grid: 4px, nearest: 12px or 16px)
+
+Suggestions:
+  - Update Button height to match pattern
+  - Replace shadow with border
+  - Adjust spacing to grid
+```
+
+**If no system.md:**
+
+```
+No design system to audit against.
+
+Create a system first:
+1. Build UI → establish system automatically
+2. Run extract → create system from existing code
+```
+
+## Implementation
+
+1. Check for `.interface-design/system.md`
+2. Parse system rules
+3. Read target files (tsx, jsx, css, scss)
+4. Compare against rules
+5. Report violations with suggestions

--- a/.cursor/rules/interface-design-critique.mdc
+++ b/.cursor/rules/interface-design-critique.mdc
@@ -1,0 +1,69 @@
+---
+description: Use when user asks to critique, review, or refine their UI build. Evaluates craft quality and rebuilds defaulted areas.
+globs:
+alwaysApply: false
+---
+
+# Critique
+
+Your first build shipped the structure. Now look at it the way a design lead reviews a junior's work — not asking "does this work?" but "would I put my name on this?"
+
+## The Gap
+
+There's a distance between correct and crafted. Correct means the layout holds, the grid aligns, the colors don't clash. Crafted means someone cared about every decision down to the last pixel. You can feel the difference immediately — the way you tell a hand-thrown mug from an injection-molded one. Both hold coffee. One has presence.
+
+Your first output lives in correct. This workflow pulls it toward crafted.
+
+## See the Composition
+
+Step back. Look at the whole thing.
+
+Does the layout have rhythm? Great interfaces breathe unevenly — dense tooling areas give way to open content, heavy elements balance against light ones, the eye travels through the page with purpose. Default layouts are monotone: same card size, same gaps, same density everywhere. Flatness is the sound of no one deciding.
+
+Are proportions doing work? A 280px sidebar next to full-width content says "navigation serves content." A 360px sidebar says "these are peers." The specific number declares what matters. If you can't articulate what your proportions are saying, they're not saying anything.
+
+Is there a clear focal point? Every screen has one thing the user came here to do. That thing should dominate — through size, position, contrast, or the space around it. When everything competes equally, nothing wins and the interface feels like a parking lot.
+
+## See the Craft
+
+Move close. Pixel-close.
+
+The spacing grid is non-negotiable — every value a multiple of 4, no exceptions — but correctness alone isn't craft. Craft is knowing that a tool panel at 16px padding feels workbench-tight while the same card at 24px feels like a brochure. The same number can be right in one context and lazy in another. Density is a design decision, not a constant.
+
+Typography should be legible even squinted. If size is the only thing separating your headline from your body from your label, the hierarchy is too weak. Weight, tracking, and opacity create layers that size alone can't.
+
+Surfaces should whisper hierarchy. Not thick borders, not dramatic shadows — quiet tonal shifts where you feel the depth without seeing it. Remove every border from your CSS mentally. Can you still perceive the structure through surface color alone? If not, your surfaces aren't working hard enough.
+
+Interactive elements need life. Every button, link, and clickable region should respond to hover and press. Not dramatically — a subtle shift in background, a gentle darkening. Missing states make an interface feel like a photograph of software instead of software.
+
+## See the Content
+
+Read every visible string as a user would. Not checking for typos — checking for truth.
+
+Does this screen tell one coherent story? Could a real person at a real company be looking at exactly this data right now? Or does the page title belong to one product, the article body to another, and the sidebar metrics to a third?
+
+Content incoherence breaks the illusion faster than any visual flaw. A beautifully designed interface with nonsensical content is a movie set with no script.
+
+## See the Structure
+
+Open the CSS and find the lies — the places that look right but are held together with tape.
+
+Negative margins undoing a parent's padding. Calc() values that exist only as workarounds. Absolute positioning to escape layout flow. Each is a shortcut where a clean solution exists. Cards with full-width dividers use flex column and section-level padding. Centered content uses max-width with auto margins. The correct answer is always simpler than the hack.
+
+## Again
+
+Look at your output one final time.
+
+Ask: "If they said this lacks craft, what would they point to?"
+
+That thing you just thought of — fix it. Then ask again.
+
+The first build was the draft. The critique is the design.
+
+## Process
+
+1. Open the file you just built
+2. Walk through each section above: composition, craft, content, structure
+3. Identify every place you defaulted instead of decided
+4. Rebuild those parts — from the decision, not from a patch
+5. Do not narrate the critique to the user. Do the work. Show the result.

--- a/.cursor/rules/interface-design-examples.mdc
+++ b/.cursor/rules/interface-design-examples.mdc
@@ -1,0 +1,92 @@
+---
+description: Real-world craft examples showing how subtle layering translates to design decisions for dashboards, sidebars, dropdowns, and form controls.
+globs:
+alwaysApply: false
+---
+
+# Craft in Action
+
+This shows how the subtle layering principle translates to real decisions. Learn the thinking, not the code. Your values will differ — the approach won't.
+
+---
+
+## The Subtle Layering Mindset
+
+Before looking at any example, internalize this: **you should barely notice the system working.**
+
+When you look at Vercel's dashboard, you don't think "nice borders." You just understand the structure. When you look at Supabase, you don't think "good surface elevation." You just know what's above what. The craft is invisible — that's how you know it's working.
+
+---
+
+## Example: Dashboard with Sidebar and Dropdown
+
+### The Surface Decisions
+
+**Why so subtle?** Each elevation jump should be only a few percentage points of lightness. You can barely see the difference in isolation. But when surfaces stack, the hierarchy emerges. This is the Vercel/Supabase way — whisper-quiet shifts that you feel rather than see.
+
+**What NOT to do:** Don't make dramatic jumps between elevations. That's jarring. Don't use different hues for different levels. Keep the same hue, shift only lightness.
+
+### The Border Decisions
+
+**Why rgba, not solid colors?** Low opacity borders blend with their background. A low-opacity white border on a dark surface is barely there — it defines the edge without demanding attention. Solid hex borders look harsh in comparison.
+
+**The test:** Look at your interface from arm's length. If borders are the first thing you notice, reduce opacity. If you can't find where regions end, increase slightly.
+
+### The Sidebar Decision
+
+**Why same background as canvas, not different?**
+
+Many dashboards make the sidebar a different color. This fragments the visual space — now you have "sidebar world" and "content world."
+
+Better: Same background, subtle border separation. The sidebar is part of the app, not a separate region. Vercel does this. Supabase does this. The border is enough.
+
+### The Dropdown Decision
+
+**Why surface-200, not surface-100?**
+
+The dropdown floats above the card it emerged from. If both were surface-100, the dropdown would blend into the card — you'd lose the sense of layering. Surface-200 is just light enough to feel "above" without being dramatically different.
+
+**Why border-overlay instead of border-default?**
+
+Overlays (dropdowns, popovers) often need slightly more definition because they're floating in space. A touch more border opacity helps them feel contained without being harsh.
+
+---
+
+## Example: Form Controls
+
+### Input Background Decision
+
+**Why darker, not lighter?**
+
+Inputs are "inset" — they receive content, they don't project it. A slightly darker background signals "type here" without needing heavy borders. This is the alternative-background principle.
+
+### Focus State Decision
+
+**Why subtle focus states?**
+
+Focus needs to be visible, but you don't need a glowing ring or dramatic color. A noticeable increase in border opacity is enough for a clear state change. Subtle-but-noticeable — the same principle as surfaces.
+
+---
+
+## Adapt to Context
+
+Your product might need:
+- Warmer hues (slight yellow/orange tint)
+- Cooler hues (blue-gray base)
+- Different lightness progression
+- Light mode (principles invert — higher elevation = shadow, not lightness)
+
+**The principle is constant:** barely different, still distinguishable. The values adapt to context.
+
+---
+
+## The Craft Check
+
+Apply the squint test to your work:
+
+1. Blur your eyes or step back
+2. Can you still perceive hierarchy?
+3. Is anything jumping out at you?
+4. Can you tell where regions begin and end?
+
+If hierarchy is visible and nothing is harsh — the subtle layering is working.

--- a/.cursor/rules/interface-design-extract.mdc
+++ b/.cursor/rules/interface-design-extract.mdc
@@ -1,0 +1,78 @@
+---
+description: Use when user asks to extract design patterns from existing code to create or update a system.md file.
+globs:
+alwaysApply: false
+---
+
+# Extract Design Patterns
+
+Extract design patterns from existing code to create a system.
+
+## Usage
+
+User says "extract", "extract patterns", or "extract <path>".
+
+## What to Extract
+
+**Scan UI files (tsx, jsx, vue, svelte) for:**
+
+1. **Repeated spacing values**
+   ```
+   Found: 4px (12x), 8px (23x), 12px (18x), 16px (31x), 24px (8x)
+   → Suggests: Base 4px, Scale: 4, 8, 12, 16, 24
+   ```
+
+2. **Repeated radius values**
+   ```
+   Found: 6px (28x), 8px (5x)
+   → Suggests: Radius scale: 6px, 8px
+   ```
+
+3. **Button patterns**
+   ```
+   Found 8 buttons:
+   - Height: 36px (7/8), 40px (1/8)
+   - Padding: 12px 16px (6/8), 16px (2/8)
+   → Suggests: Button pattern: 36px h, 12px 16px padding
+   ```
+
+4. **Card patterns**
+   ```
+   Found 12 cards:
+   - Border: 1px solid (10/12), none (2/12)
+   - Padding: 16px (9/12), 20px (3/12)
+   → Suggests: Card pattern: 1px border, 16px padding
+   ```
+
+5. **Depth strategy**
+   ```
+   box-shadow found: 2x
+   border found: 34x
+   → Suggests: Borders-only depth
+   ```
+
+**Then prompt the user:**
+```
+Extracted patterns:
+
+Spacing:
+  Base: 4px
+  Scale: 4, 8, 12, 16, 24, 32
+
+Depth: Borders-only (34 borders, 2 shadows)
+
+Patterns:
+  Button: 36px h, 12px 16px pad, 6px radius
+  Card: 1px border, 16px pad
+
+Create .interface-design/system.md with these? (y/n/customize)
+```
+
+## Implementation
+
+1. Search for UI files
+2. Parse for repeated values
+3. Identify common patterns
+4. Suggest system based on frequency
+5. Offer to create `.interface-design/system.md`
+6. Let user customize before saving

--- a/.cursor/rules/interface-design-init.mdc
+++ b/.cursor/rules/interface-design-init.mdc
@@ -1,0 +1,73 @@
+---
+description: Use when user asks to build, design, or create UI — dashboards, apps, tools, admin panels. Starts the craft-first design workflow.
+globs:
+alwaysApply: false
+---
+
+# Build UI with Craft
+
+**Scope:** Dashboards, apps, tools, admin panels. Not landing pages or marketing sites.
+
+## Intent First — Answer Before Building
+
+Before touching code, answer these out loud:
+
+**Who is this human?** Not "users." Where are they? What's on their mind? A teacher at 7am with coffee is not a developer debugging at midnight.
+
+**What must they accomplish?** Not "use the dashboard." The verb. Grade submissions. Find the broken deployment. Approve the payment.
+
+**What should this feel like?** In words that mean something. "Clean" means nothing. Warm like a notebook? Cold like a terminal? Dense like a trading floor?
+
+If you cannot answer these with specifics, stop and ask the user. Do not guess. Do not default.
+
+## Before Writing Each Component
+
+State the intent AND the technical approach:
+
+```
+Intent: [who, what they need to do, how it should feel]
+Palette: [foundation + accent — and WHY these colors fit the product's world]
+Depth: [borders / subtle shadows / layered — and WHY]
+Surfaces: [your elevation scale — and WHY this temperature]
+Typography: [your typeface choice — and WHY it fits the intent]
+Spacing: [your base unit]
+```
+
+Every choice must be explainable. If your answer is "it's common" or "it works" — you haven't chosen. You've defaulted.
+
+**The test:** If another AI given a similar prompt would produce the same output, you have failed. The interface must emerge from THIS user, THIS problem, THIS intent.
+
+## Communication
+
+Be invisible. Don't announce modes or narrate process.
+
+**Never say:** "I'm in ESTABLISH MODE", "Let me check system.md..."
+
+**Instead:** Jump into work. State suggestions with reasoning.
+
+## Suggest + Ask
+
+Lead with your exploration and recommendation, then confirm:
+```
+"Domain: [concepts from this product's world]
+Color world: [colors that exist in this domain]
+Signature: [one element unique to this product]
+
+Direction: [approach that connects to the above]"
+
+[Ask: "Does that direction feel right?"]
+```
+
+## Flow
+
+1. Check if `.interface-design/system.md` exists
+2. **If exists**: Apply established patterns from system.md
+3. **If not**: Assess context, suggest direction, get confirmation, build
+
+## After Every Task
+
+Offer to save when you finish building UI:
+
+"Want me to save these patterns to `.interface-design/system.md`?"
+
+Always offer — new patterns should be captured whether system.md exists or not.

--- a/.cursor/rules/interface-design-principles.mdc
+++ b/.cursor/rules/interface-design-principles.mdc
@@ -1,0 +1,241 @@
+---
+description: Detailed craft principles with code examples for surfaces, spacing, depth, typography, animation, and dark mode. Referenced when building or modifying UI components.
+globs: "*.tsx,*.jsx,*.vue,*.svelte,*.css,*.scss"
+alwaysApply: false
+---
+
+# Core Craft Principles
+
+These apply regardless of design direction. This is the quality floor.
+
+---
+
+## Surface & Token Architecture
+
+Professional interfaces don't pick colors randomly — they build systems. Understanding this architecture is the difference between "looks okay" and "feels like a real product."
+
+### The Primitive Foundation
+
+Every color in your interface should trace back to a small set of primitives:
+
+- **Foreground** — text colors (primary, secondary, muted)
+- **Background** — surface colors (base, elevated, overlay)
+- **Border** — edge colors (default, subtle, strong)
+- **Brand** — your primary accent
+- **Semantic** — functional colors (destructive, warning, success)
+
+Don't invent new colors. Map everything to these primitives.
+
+### Surface Elevation Hierarchy
+
+Surfaces stack. A dropdown sits above a card which sits above the page. Build a numbered system:
+
+```
+Level 0: Base background (the app canvas)
+Level 1: Cards, panels (same visual plane as base)
+Level 2: Dropdowns, popovers (floating above)
+Level 3: Nested dropdowns, stacked overlays
+Level 4: Highest elevation (rare)
+```
+
+In dark mode, higher elevation = slightly lighter. In light mode, higher elevation = slightly lighter or uses shadow. The principle: **elevated surfaces need visual distinction from what's beneath them.**
+
+### The Subtlety Principle
+
+This is where most interfaces fail. Study Vercel, Supabase, Linear — their surfaces are **barely different** but still distinguishable. Their borders are **light but not invisible**.
+
+**For surfaces:** The difference between elevation levels should be subtle — a few percentage points of lightness, not dramatic jumps. In dark mode, surface-100 might be 7% lighter than base, surface-200 might be 9%, surface-300 might be 12%. You can barely see it, but you feel it.
+
+**For borders:** Borders should define regions without demanding attention. Use low opacity (0.05-0.12 alpha for dark mode, slightly higher for light). The border should disappear when you're not looking for it, but be findable when you need to understand the structure.
+
+**The test:** Squint at your interface. You should still perceive the hierarchy — what's above what, where regions begin and end. But no single border or surface should jump out at you. If borders are the first thing you notice, they're too strong. If you can't find where one region ends and another begins, they're too subtle.
+
+**Common AI mistakes to avoid:**
+- Borders that are too visible (1px solid gray instead of subtle rgba)
+- Surface jumps that are too dramatic (going from dark to light instead of dark to slightly-less-dark)
+- Using different hues for different surfaces (gray card on blue background)
+- Harsh dividers where subtle borders would do
+
+### Text Hierarchy via Tokens
+
+Don't just have "text" and "gray text." Build four levels:
+
+- **Primary** — default text, highest contrast
+- **Secondary** — supporting text, slightly muted
+- **Tertiary** — metadata, timestamps, less important
+- **Muted** — disabled, placeholder, lowest contrast
+
+Use all four consistently. If you're only using two, your hierarchy is too flat.
+
+### Border Progression
+
+Borders aren't binary. Build a scale:
+
+- **Default** — standard borders
+- **Subtle/Muted** — softer separation
+- **Strong** — emphasis, hover states
+- **Stronger** — maximum emphasis, focus rings
+
+Match border intensity to the importance of the boundary.
+
+### Dedicated Control Tokens
+
+Form controls (inputs, checkboxes, selects) have specific needs. Don't just reuse surface tokens — create dedicated ones:
+
+- **Control background** — often different from surface backgrounds
+- **Control border** — needs to feel interactive
+- **Control focus** — clear focus indication
+
+This separation lets you tune controls independently from layout surfaces.
+
+### Context-Aware Bases
+
+Different areas of your app might need different base surfaces:
+
+- **Marketing pages** — might use darker/richer backgrounds
+- **Dashboard/app** — might use neutral working backgrounds
+- **Sidebar** — might differ from main canvas
+
+The surface hierarchy works the same way — it just starts from a different base.
+
+### Alternative Backgrounds for Depth
+
+Beyond shadows, use contrasting backgrounds to create depth. An "alternative" or "inset" background makes content feel recessed. Useful for:
+
+- Empty states in data grids
+- Code blocks
+- Inset panels
+- Visual grouping without borders
+
+---
+
+## Spacing System
+
+Pick a base unit (4px and 8px are common) and use multiples throughout. The specific number matters less than consistency — every spacing value should be explainable as "X times the base unit."
+
+Build a scale for different contexts:
+- Micro spacing (icon gaps, tight element pairs)
+- Component spacing (within buttons, inputs, cards)
+- Section spacing (between related groups)
+- Major separation (between distinct sections)
+
+## Symmetrical Padding
+
+TLBR must match. If top padding is 16px, left/bottom/right must also be 16px. Exception: when content naturally creates visual balance.
+
+```css
+/* Good */
+padding: 16px;
+padding: 12px 16px; /* Only when horizontal needs more room */
+
+/* Bad */
+padding: 24px 16px 12px 16px;
+```
+
+## Border Radius Consistency
+
+Sharper corners feel technical, rounder corners feel friendly. Pick a scale that fits your product's personality and use it consistently.
+
+The key is having a system: small radius for inputs and buttons, medium for cards, large for modals or containers. Don't mix sharp and soft randomly — inconsistent radius is as jarring as inconsistent spacing.
+
+## Depth & Elevation Strategy
+
+Match your depth approach to your design direction. Choose ONE and commit:
+
+**Borders-only (flat)** — Clean, technical, dense. Works for utility-focused tools where information density matters more than visual lift. Linear, Raycast, and many developer tools use almost no shadows — just subtle borders to define regions.
+
+**Subtle single shadows** — Soft lift without complexity. A simple `0 1px 3px rgba(0,0,0,0.08)` can be enough. Works for approachable products that want gentle depth.
+
+**Layered shadows** — Rich, premium, dimensional. Multiple shadow layers create realistic depth. Stripe and Mercury use this approach. Best for cards that need to feel like physical objects.
+
+**Surface color shifts** — Background tints establish hierarchy without any shadows. A card at `#fff` on a `#f8fafc` background already feels elevated.
+
+```css
+/* Borders-only approach */
+--border: rgba(0, 0, 0, 0.08);
+--border-subtle: rgba(0, 0, 0, 0.05);
+border: 0.5px solid var(--border);
+
+/* Single shadow approach */
+--shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+
+/* Layered shadow approach */
+--shadow-layered:
+  0 0 0 0.5px rgba(0, 0, 0, 0.05),
+  0 1px 2px rgba(0, 0, 0, 0.04),
+  0 2px 4px rgba(0, 0, 0, 0.03),
+  0 4px 8px rgba(0, 0, 0, 0.02);
+```
+
+## Card Layouts
+
+Monotonous card layouts are lazy design. A metric card doesn't have to look like a plan card doesn't have to look like a settings card.
+
+Design each card's internal structure for its specific content — but keep the surface treatment consistent: same border weight, shadow depth, corner radius, padding scale, typography.
+
+## Isolated Controls
+
+UI controls deserve container treatment. Date pickers, filters, dropdowns — these should feel like crafted objects.
+
+**Never use native form elements for styled UI.** Native `<select>`, `<input type="date">`, and similar elements render OS-native dropdowns that cannot be styled. Build custom components instead:
+
+- Custom select: trigger button + positioned dropdown menu
+- Custom date picker: input + calendar popover
+- Custom checkbox/radio: styled div with state management
+
+Custom select triggers must use `display: inline-flex` with `white-space: nowrap` to keep text and chevron icons on the same row.
+
+## Typography Hierarchy
+
+Build distinct levels that are visually distinguishable at a glance:
+
+- **Headlines** — heavier weight, tighter letter-spacing for presence
+- **Body** — comfortable weight for readability
+- **Labels/UI** — medium weight, works at smaller sizes
+- **Data** — often monospace, needs `tabular-nums` for alignment
+
+Don't rely on size alone. Combine size, weight, and letter-spacing to create clear hierarchy. If you squint and can't tell headline from body, the hierarchy is too weak.
+
+## Monospace for Data
+
+Numbers, IDs, codes, timestamps belong in monospace. Use `tabular-nums` for columnar alignment. Mono signals "this is data."
+
+## Iconography
+
+Icons clarify, not decorate — if removing an icon loses no meaning, remove it. Choose a consistent icon set and stick with it throughout the product.
+
+Give standalone icons presence with subtle background containers. Icons next to text should align optically, not mathematically.
+
+## Animation
+
+Keep it fast and functional. Micro-interactions (hover, focus) should feel instant — around 150ms. Larger transitions (modals, panels) can be slightly longer — 200-250ms.
+
+Use smooth deceleration easing (ease-out variants). Avoid spring/bounce effects in professional interfaces — they feel playful, not serious.
+
+## Contrast Hierarchy
+
+Build a four-level system: foreground (primary) → secondary → muted → faint. Use all four consistently.
+
+## Color Carries Meaning
+
+Gray builds structure. Color communicates — status, action, emphasis, identity. Unmotivated color is noise. Color that reinforces the product's world is character.
+
+## Navigation Context
+
+Screens need grounding. A data table floating in space feels like a component demo, not a product. Consider including:
+
+- **Navigation** — sidebar or top nav showing where you are in the app
+- **Location indicator** — breadcrumbs, page title, or active nav state
+- **User context** — who's logged in, what workspace/org
+
+When building sidebars, consider using the same background as the main content area. Rely on a subtle border for separation rather than different background colors.
+
+## Dark Mode
+
+Dark interfaces have different needs:
+
+**Borders over shadows** — Shadows are less visible on dark backgrounds. Lean more on borders for definition.
+
+**Adjust semantic colors** — Status colors (success, warning, error) often need to be slightly desaturated for dark backgrounds.
+
+**Same structure, different values** — The hierarchy system still applies, just with inverted values.

--- a/.cursor/rules/interface-design-status.mdc
+++ b/.cursor/rules/interface-design-status.mdc
@@ -1,0 +1,51 @@
+---
+description: Use when user asks for design system status, current state, or what patterns are defined.
+globs:
+alwaysApply: false
+---
+
+# Design System Status
+
+Show current design system state.
+
+## What to Show
+
+**If `.interface-design/system.md` exists:**
+
+Display:
+```
+Design System: [Project Name]
+
+Direction: [Precision & Density / Warmth / etc]
+Foundation: [Cool slate / Warm stone / etc]
+Depth: [Borders-only / Subtle shadows / Layered]
+
+Tokens:
+- Spacing base: 4px
+- Radius scale: 4px, 6px, 8px
+- Colors: [count] defined
+
+Patterns:
+- Button Primary (36px h, 16px px, 6px radius)
+- Card Default (border, 16px pad)
+- [other patterns...]
+
+Last updated: [from git or file mtime]
+```
+
+**If no system.md:**
+
+```
+No design system found.
+
+Options:
+1. Build UI → system will be established automatically
+2. Run extract → pull patterns from existing code
+```
+
+## Implementation
+
+1. Read `.interface-design/system.md`
+2. Parse direction, tokens, patterns
+3. Format and display
+4. If no system, suggest next steps

--- a/.cursor/rules/interface-design-templates.mdc
+++ b/.cursor/rules/interface-design-templates.mdc
@@ -1,0 +1,203 @@
+---
+description: Design system templates and reference examples (precision/density and warmth/approachability). Use when creating new system.md files or establishing design direction.
+globs:
+alwaysApply: false
+---
+
+# Design System Template
+
+Use this template when creating `.interface-design/system.md` for a new project.
+
+## Template
+
+```markdown
+# Design System
+
+## Direction
+
+**Personality:** [Precision & Density | Warmth & Approachability | Sophistication & Trust | Boldness & Clarity | Utility & Function | Data & Analysis]
+
+**Foundation:** [warm | cool | neutral | tinted]
+
+**Depth:** [borders-only | subtle-shadows | layered-shadows]
+
+## Tokens
+
+### Spacing
+Base: [4px | 8px]
+Scale: [4, 8, 12, 16, 24, 32, 64]
+
+### Colors
+--foreground: [slate-900]
+--secondary: [slate-600]
+--muted: [slate-400]
+--faint: [slate-200]
+--accent: [blue-600]
+
+### Radius
+Scale: [4px, 6px, 8px] (sharp) | [8px, 12px, 16px] (soft)
+
+### Typography
+Font: [system | Inter | Geist]
+Scale: 12, 13, 14 (base), 16, 18, 24, 32
+Weights: 400, 500, 600
+
+## Patterns
+
+### Button Primary
+- Height: 36px
+- Padding: 12px 16px
+- Radius: 6px
+- Font: 14px, 500 weight
+- Background: accent color
+- Usage: Primary actions
+
+### Card Default
+- Border: 0.5px solid (faint)
+- Padding: 16px
+- Radius: 8px
+- Background: white
+- Usage: Content containers
+
+## Decisions
+
+| Decision | Rationale | Date |
+|----------|-----------|------|
+| Borders-only depth | Dashboard tool, users want density. Shadows add visual weight without information value. | YYYY-MM-DD |
+| 4px spacing base | Tight enough for data tables, divisible by common UI sizes | YYYY-MM-DD |
+```
+
+---
+
+# Example: Precision & Density
+
+For dashboard/admin interfaces.
+
+```markdown
+# Design System - Precision & Density
+
+## Direction
+
+**Personality:** Precision & Density
+**Foundation:** Cool (slate)
+**Depth:** Borders-only
+
+## Tokens
+
+### Spacing
+Base: 4px
+Scale: 4, 8, 12, 16, 24, 32
+
+### Colors
+--foreground: slate-900
+--secondary: slate-600
+--muted: slate-400
+--faint: slate-200
+--border: rgba(0, 0, 0, 0.08)
+--accent: blue-600
+
+### Radius
+Scale: 4px, 6px, 8px (sharp, technical)
+
+### Typography
+Font: system-ui (fast, native)
+Scale: 11, 12, 13, 14 (base), 16, 18
+Weights: 400, 500, 600
+Mono: SF Mono, Consolas (for data)
+
+## Patterns
+
+### Button
+- Height: 32px (compact)
+- Padding: 8px 12px
+- Radius: 4px
+- Font: 13px, 500 weight
+- Border: 1px solid
+
+### Card
+- Border: 0.5px solid (faint)
+- Padding: 12px
+- Radius: 6px
+- No shadow
+
+### Table Cell
+- Padding: 8px 12px
+- Font: 13px tabular-nums
+- Border-bottom: 1px solid (faint)
+
+## Decisions
+
+| Decision | Rationale | Date |
+|----------|-----------|------|
+| Borders-only | Information density matters more than lift | 2026-01-15 |
+| Compact sizing | Power users, high information density | 2026-01-15 |
+| System fonts | Performance, native feel | 2026-01-15 |
+```
+
+---
+
+# Example: Warmth & Approachability
+
+For collaborative/consumer apps.
+
+```markdown
+# Design System - Warmth & Approachability
+
+## Direction
+
+**Personality:** Warmth & Approachability
+**Foundation:** Warm (stone)
+**Depth:** Subtle shadows
+
+## Tokens
+
+### Spacing
+Base: 4px
+Scale: 8, 12, 16, 24, 32, 48 (generous)
+
+### Colors
+--foreground: stone-900
+--secondary: stone-600
+--muted: stone-400
+--faint: stone-200
+--accent: orange-500
+--shadow: 0 1px 3px rgba(0, 0, 0, 0.08)
+
+### Radius
+Scale: 8px, 12px, 16px (soft, friendly)
+
+### Typography
+Font: Inter (approachable, readable)
+Scale: 13, 14, 15, 16 (base), 18, 20, 24
+Weights: 400, 500, 600
+
+## Patterns
+
+### Button
+- Height: 40px (comfortable)
+- Padding: 12px 20px
+- Radius: 8px
+- Font: 15px, 500 weight
+- Shadow: subtle
+
+### Card
+- Border: none
+- Padding: 20px
+- Radius: 12px
+- Shadow: 0 1px 3px rgba(0,0,0,0.08)
+- Background: white on stone-50
+
+### Input
+- Height: 44px
+- Padding: 12px 16px
+- Radius: 8px
+- Border: 1.5px solid (faint)
+
+## Decisions
+
+| Decision | Rationale | Date |
+|----------|-----------|------|
+| Subtle shadows | Gentle depth, approachable feel | 2026-01-15 |
+| Generous spacing | Focused tasks, not cramming info | 2026-01-15 |
+| Warm foundation | Human, comfortable, inviting | 2026-01-15 |
+```

--- a/.cursor/rules/interface-design-validation.mdc
+++ b/.cursor/rules/interface-design-validation.mdc
@@ -1,0 +1,54 @@
+---
+description: Memory management rules for when and how to update .interface-design/system.md with design patterns.
+globs:
+alwaysApply: false
+---
+
+# Memory Management
+
+When and how to update `.interface-design/system.md`.
+
+## When to Add Patterns
+
+Add to system.md when:
+- Component used 2+ times
+- Pattern is reusable across the project
+- Has specific measurements worth remembering
+
+## Pattern Format
+
+```markdown
+### Button Primary
+- Height: 36px
+- Padding: 12px 16px
+- Radius: 6px
+- Font: 14px, 500 weight
+```
+
+## Don't Document
+
+- One-off components
+- Temporary experiments
+- Variations better handled with props
+
+## Pattern Reuse
+
+Before creating a component, check system.md:
+- Pattern exists? Use it.
+- Need variation? Extend, don't create new.
+
+Memory compounds: each pattern saved makes future work faster and more consistent.
+
+---
+
+# Validation Checks
+
+If system.md defines specific values, check consistency:
+
+**Spacing** — All values multiples of the defined base?
+
+**Depth** — Using the declared strategy throughout? (borders-only means no shadows)
+
+**Colors** — Using defined palette, not random hex codes?
+
+**Patterns** — Reusing documented patterns instead of creating new?

--- a/.cursor/rules/interface-design.mdc
+++ b/.cursor/rules/interface-design.mdc
@@ -1,0 +1,388 @@
+---
+description:
+globs:
+alwaysApply: true
+---
+
+# Interface Design
+
+Build interface design with craft and consistency.
+
+## Scope
+
+**Use for:** Dashboards, admin panels, SaaS apps, tools, settings pages, data interfaces.
+
+**Not for:** Landing pages, marketing sites, campaigns.
+
+---
+
+# The Problem
+
+You will generate generic output. Your training has seen thousands of dashboards. The patterns are strong.
+
+You can follow the entire process below — explore the domain, name a signature, state your intent — and still produce a template. Warm colors on cold structures. Friendly fonts on generic layouts. "Kitchen feel" that looks like every other app.
+
+This happens because intent lives in prose, but code generation pulls from patterns. The gap between them is where defaults win.
+
+The process below helps. But process alone doesn't guarantee craft. You have to catch yourself.
+
+---
+
+# Where Defaults Hide
+
+Defaults don't announce themselves. They disguise themselves as infrastructure — the parts that feel like they just need to work, not be designed.
+
+**Typography feels like a container.** Pick something readable, move on. But typography isn't holding your design — it IS your design. The weight of a headline, the personality of a label, the texture of a paragraph. These shape how the product feels before anyone reads a word. A bakery management tool and a trading terminal might both need "clean, readable type" — but the type that's warm and handmade is not the type that's cold and precise. If you're reaching for your usual font, you're not designing.
+
+**Navigation feels like scaffolding.** Build the sidebar, add the links, get to the real work. But navigation isn't around your product — it IS your product. Where you are, where you can go, what matters most. A page floating in space is a component demo, not software. The navigation teaches people how to think about the space they're in.
+
+**Data feels like presentation.** You have numbers, show numbers. But a number on screen is not design. The question is: what does this number mean to the person looking at it? What will they do with it? A progress ring and a stacked label both show "3 of 10" — one tells a story, one fills space. If you're reaching for number-on-label, you're not designing.
+
+**Token names feel like implementation detail.** But your CSS variables are design decisions. `--ink` and `--parchment` evoke a world. `--gray-700` and `--surface-2` evoke a template. Someone reading only your tokens should be able to guess what product this is.
+
+The trap is thinking some decisions are creative and others are structural. There are no structural decisions. Everything is design. The moment you stop asking "why this?" is the moment defaults take over.
+
+---
+
+# Intent First
+
+Before touching code, answer these. Not in your head — out loud, to yourself or the user.
+
+**Who is this human?**
+Not "users." The actual person. Where are they when they open this? What's on their mind? What did they do 5 minutes ago, what will they do 5 minutes after? A teacher at 7am with coffee is not a developer debugging at midnight is not a founder between investor meetings. Their world shapes the interface.
+
+**What must they accomplish?**
+Not "use the dashboard." The verb. Grade these submissions. Find the broken deployment. Approve the payment. The answer determines what leads, what follows, what hides.
+
+**What should this feel like?**
+Say it in words that mean something. "Clean and modern" means nothing — every AI says that. Warm like a notebook? Cold like a terminal? Dense like a trading floor? Calm like a reading app? The answer shapes color, type, spacing, density — everything.
+
+If you cannot answer these with specifics, stop. Ask the user. Do not guess. Do not default.
+
+## Every Choice Must Be A Choice
+
+For every decision, you must be able to explain WHY.
+
+- Why this layout and not another?
+- Why this color temperature?
+- Why this typeface?
+- Why this spacing scale?
+- Why this information hierarchy?
+
+If your answer is "it's common" or "it's clean" or "it works" — you haven't chosen. You've defaulted. Defaults are invisible. Invisible choices compound into generic output.
+
+**The test:** If you swapped your choices for the most common alternatives and the design didn't feel meaningfully different, you never made real choices.
+
+## Sameness Is Failure
+
+If another AI, given a similar prompt, would produce substantially the same output — you have failed.
+
+This is not about being different for its own sake. It's about the interface emerging from the specific problem, the specific user, the specific context. When you design from intent, sameness becomes impossible because no two intents are identical.
+
+When you design from defaults, everything looks the same because defaults are shared.
+
+## Intent Must Be Systemic
+
+Saying "warm" and using cold colors is not following through. Intent is not a label — it's a constraint that shapes every decision.
+
+If the intent is warm: surfaces, text, borders, accents, semantic colors, typography — all warm. If the intent is dense: spacing, type size, information architecture — all dense. If the intent is calm: motion, contrast, color saturation — all calm.
+
+Check your output against your stated intent. Does every token reinforce it? Or did you state an intent and then default anyway?
+
+---
+
+# Product Domain Exploration
+
+This is where defaults get caught — or don't.
+
+Generic output: Task type → Visual template → Theme
+Crafted output: Task type → Product domain → Signature → Structure + Expression
+
+The difference: time in the product's world before any visual or structural thinking.
+
+## Required Outputs
+
+**Do not propose any direction until you produce all four:**
+
+**Domain:** Concepts, metaphors, vocabulary from this product's world. Not features — territory. Minimum 5.
+
+**Color world:** What colors exist naturally in this product's domain? Not "warm" or "cool" — go to the actual world. If this product were a physical space, what would you see? What colors belong there that don't belong elsewhere? List 5+.
+
+**Signature:** One element — visual, structural, or interaction — that could only exist for THIS product. If you can't name one, keep exploring.
+
+**Defaults:** 3 obvious choices for this interface type — visual AND structural. You can't avoid patterns you haven't named.
+
+## Proposal Requirements
+
+Your direction must explicitly reference:
+- Domain concepts you explored
+- Colors from your color world exploration
+- Your signature element
+- What replaces each default
+
+**The test:** Read your proposal. Remove the product name. Could someone identify what this is for? If not, it's generic. Explore deeper.
+
+---
+
+# The Mandate
+
+**Before showing the user, look at what you made.**
+
+Ask yourself: "If they said this lacks craft, what would they mean?"
+
+That thing you just thought of — fix it first.
+
+Your first output is probably generic. That's normal. The work is catching it before the user has to.
+
+## The Checks
+
+Run these against your output before presenting:
+
+- **The swap test:** If you swapped the typeface for your usual one, would anyone notice? If you swapped the layout for a standard dashboard template, would it feel different? The places where swapping wouldn't matter are the places you defaulted.
+
+- **The squint test:** Blur your eyes. Can you still perceive hierarchy? Is anything jumping out harshly? Craft whispers.
+
+- **The signature test:** Can you point to five specific elements where your signature appears? Not "the overall feel" — actual components. A signature you can't locate doesn't exist.
+
+- **The token test:** Read your CSS variables out loud. Do they sound like they belong to this product's world, or could they belong to any project?
+
+If any check fails, iterate before showing.
+
+---
+
+# Craft Foundations
+
+## Subtle Layering
+
+This is the backbone of craft. Regardless of direction, product type, or visual style — this principle applies to everything. You should barely notice the system working. When you look at Vercel's dashboard, you don't think "nice borders." You just understand the structure. The craft is invisible — that's how you know it's working.
+
+### Surface Elevation
+
+Surfaces stack. A dropdown sits above a card which sits above the page. Build a numbered system — base, then increasing elevation levels. In dark mode, higher elevation = slightly lighter. In light mode, higher elevation = slightly lighter or uses shadow.
+
+Each jump should be only a few percentage points of lightness. You can barely see the difference in isolation. But when surfaces stack, the hierarchy emerges. Whisper-quiet shifts that you feel rather than see.
+
+**Key decisions:**
+- **Sidebars:** Same background as canvas, not different. Different colors fragment the visual space into "sidebar world" and "content world." A subtle border is enough separation.
+- **Dropdowns:** One level above their parent surface. If both share the same level, the dropdown blends into the card and layering is lost.
+- **Inputs:** Slightly darker than their surroundings, not lighter. Inputs are "inset" — they receive content. A darker background signals "type here" without heavy borders.
+
+### Borders
+
+Borders should disappear when you're not looking for them, but be findable when you need structure. Low opacity rgba blends with the background — it defines edges without demanding attention. Solid hex borders look harsh in comparison.
+
+Build a progression — not all borders are equal. Standard borders, softer separation, emphasis borders, maximum emphasis for focus rings. Match intensity to the importance of the boundary.
+
+**The squint test:** Blur your eyes at the interface. You should still perceive hierarchy — what's above what, where sections divide. But nothing should jump out. No harsh lines. No jarring color shifts. Just quiet structure.
+
+This separates professional interfaces from amateur ones. Get this wrong and nothing else matters.
+
+## Infinite Expression
+
+Every pattern has infinite expressions. **No interface should look the same.**
+
+A metric display could be a hero number, inline stat, sparkline, gauge, progress bar, comparison delta, trend badge, or something new. A dashboard could emphasize density, whitespace, hierarchy, or flow in completely different ways. Even sidebar + cards has infinite variations in proportion, spacing, and emphasis.
+
+**Before building, ask:**
+- What's the ONE thing users do most here?
+- What products solve similar problems brilliantly? Study them.
+- Why would this interface feel designed for its purpose, not templated?
+
+**NEVER produce identical output.** Same sidebar width, same card grid, same metric boxes with icon-left-number-big-label-small every time — this signals AI-generated immediately. It's forgettable.
+
+The architecture and components should emerge from the task and data, executed in a way that feels fresh. Linear's cards don't look like Notion's. Vercel's metrics don't look like Stripe's. Same concepts, infinite expressions.
+
+## Color Lives Somewhere
+
+Every product exists in a world. That world has colors.
+
+Before you reach for a palette, spend time in the product's world. What would you see if you walked into the physical version of this space? What materials? What light? What objects?
+
+Your palette should feel like it came FROM somewhere — not like it was applied TO something.
+
+**Beyond Warm and Cold:** Temperature is one axis. Is this quiet or loud? Dense or spacious? Serious or playful? Geometric or organic? A trading terminal and a meditation app are both "focused" — completely different kinds of focus. Find the specific quality, not the generic label.
+
+**Color Carries Meaning:** Gray builds structure. Color communicates — status, action, emphasis, identity. Unmotivated color is noise. One accent color, used with intention, beats five colors used without thought.
+
+---
+
+# Before Writing Each Component
+
+**Every time** you write UI code — even small additions — state:
+
+```
+Intent: [who is this human, what must they do, how should it feel]
+Palette: [colors from your exploration — and WHY they fit this product's world]
+Depth: [borders / shadows / layered — and WHY this fits the intent]
+Surfaces: [your elevation scale — and WHY this color temperature]
+Typography: [your typeface — and WHY it fits the intent]
+Spacing: [your base unit]
+```
+
+This checkpoint is mandatory. It forces you to connect every technical choice back to intent.
+
+If you can't explain WHY for each choice, you're defaulting. Stop and think.
+
+---
+
+# Design Principles
+
+## Token Architecture
+
+Every color in your interface should trace back to a small set of primitives: foreground (text hierarchy), background (surface elevation), border (separation hierarchy), brand, and semantic (destructive, warning, success). No random hex values — everything maps to primitives.
+
+### Text Hierarchy
+
+Don't just have "text" and "gray text." Build four levels — primary, secondary, tertiary, muted. Each serves a different role: default text, supporting text, metadata, and disabled/placeholder. Use all four consistently. If you're only using two, your hierarchy is too flat.
+
+### Border Progression
+
+Borders aren't binary. Build a scale that matches intensity to importance — standard separation, softer separation, emphasis, maximum emphasis. Not every boundary deserves the same weight.
+
+### Control Tokens
+
+Form controls have specific needs. Don't reuse surface tokens — create dedicated ones for control backgrounds, control borders, and focus states. This lets you tune interactive elements independently from layout surfaces.
+
+## Spacing
+
+Pick a base unit and stick to multiples. Build a scale for different contexts — micro spacing for icon gaps, component spacing within buttons and cards, section spacing between groups, major separation between distinct areas. Random values signal no system.
+
+## Padding
+
+Keep it symmetrical. If one side has a value, others should match unless content naturally requires asymmetry.
+
+## Depth
+
+Choose ONE approach and commit:
+- **Borders-only** — Clean, technical. For dense tools.
+- **Subtle shadows** — Soft lift. For approachable products.
+- **Layered shadows** — Premium, dimensional. For cards that need presence.
+- **Surface color shifts** — Background tints establish hierarchy without shadows.
+
+Don't mix approaches.
+
+## Border Radius
+
+Sharper feels technical. Rounder feels friendly. Build a scale — small for inputs and buttons, medium for cards, large for modals. Don't mix sharp and soft randomly.
+
+## Typography
+
+Build distinct levels distinguishable at a glance. Headlines need weight and tight tracking for presence. Body needs comfortable weight for readability. Labels need medium weight that works at smaller sizes. Data needs monospace with tabular number spacing for alignment. Don't rely on size alone — combine size, weight, and letter-spacing.
+
+## Card Layouts
+
+A metric card doesn't have to look like a plan card doesn't have to look like a settings card. Design each card's internal structure for its specific content — but keep the surface treatment consistent: same border weight, shadow depth, corner radius, padding scale.
+
+## Controls
+
+Native `<select>` and `<input type="date">` render OS-native elements that cannot be styled. Build custom components — trigger buttons with positioned dropdowns, calendar popovers, styled state management.
+
+## Iconography
+
+Icons clarify, not decorate — if removing an icon loses no meaning, remove it. Choose one icon set and stick with it. Give standalone icons presence with subtle background containers.
+
+## Animation
+
+Fast micro-interactions, smooth easing. Larger transitions can be slightly longer. Use deceleration easing. Avoid spring/bounce in professional interfaces.
+
+## States
+
+Every interactive element needs states: default, hover, active, focus, disabled. Data needs states too: loading, empty, error. Missing states feel broken.
+
+## Navigation Context
+
+Screens need grounding. A data table floating in space feels like a component demo, not a product. Include navigation showing where you are in the app, location indicators, and user context. When building sidebars, consider same background as main content with border separation rather than different colors.
+
+## Dark Mode
+
+Dark interfaces have different needs. Shadows are less visible on dark backgrounds — lean on borders for definition. Semantic colors (success, warning, error) often need slight desaturation. The hierarchy system still applies, just with inverted values.
+
+---
+
+# Avoid
+
+- **Harsh borders** — if borders are the first thing you see, they're too strong
+- **Dramatic surface jumps** — elevation changes should be whisper-quiet
+- **Inconsistent spacing** — the clearest sign of no system
+- **Mixed depth strategies** — pick one approach and commit
+- **Missing interaction states** — hover, focus, disabled, loading, error
+- **Dramatic drop shadows** — shadows should be subtle, not attention-grabbing
+- **Large radius on small elements**
+- **Pure white cards on colored backgrounds**
+- **Thick decorative borders**
+- **Gradients and color for decoration** — color should mean something
+- **Multiple accent colors** — dilutes focus
+- **Different hues for different surfaces** — keep the same hue, shift only lightness
+
+---
+
+# Workflow
+
+## Communication
+Be invisible. Don't announce modes or narrate process.
+
+**Never say:** "I'm in ESTABLISH MODE", "Let me check system.md..."
+
+**Instead:** Jump into work. State suggestions with reasoning.
+
+## Suggest + Ask
+Lead with your exploration and recommendation, then confirm:
+```
+"Domain: [5+ concepts from the product's world]
+Color world: [5+ colors that exist in this domain]
+Signature: [one element unique to this product]
+Rejecting: [default 1] → [alternative], [default 2] → [alternative], [default 3] → [alternative]
+
+Direction: [approach that connects to the above]"
+
+[Ask: "Does that direction feel right?"]
+```
+
+## If Project Has system.md
+Read `.interface-design/system.md` and apply. Decisions are made.
+
+## If No system.md
+1. Explore domain — Produce all four required outputs
+2. Propose — Direction must reference all four
+3. Confirm — Get user buy-in
+4. Build — Apply principles
+5. **Evaluate** — Run the mandate checks before showing
+6. Offer to save
+
+---
+
+# After Completing a Task
+
+When you finish building something, **always offer to save**:
+
+```
+"Want me to save these patterns for future sessions?"
+```
+
+If yes, write to `.interface-design/system.md`:
+- Direction and feel
+- Depth strategy (borders/shadows/layered)
+- Spacing base unit
+- Key component patterns
+
+### What to Save
+
+Add patterns when a component is used 2+ times, is reusable across the project, or has specific measurements worth remembering. Don't save one-off components, temporary experiments, or variations better handled with props.
+
+### Consistency Checks
+
+If system.md defines values, check against them: spacing on the defined grid, depth using the declared strategy throughout, colors from the defined palette, documented patterns reused instead of reinvented.
+
+This compounds — each save makes future work faster and more consistent.
+
+---
+
+# Available Workflows
+
+When the user asks for these, the corresponding rules will be pulled in automatically:
+
+- **"init" or "build UI"** — Start building with craft-first approach
+- **"status"** — Show current design system state
+- **"audit"** — Check code against design system
+- **"extract"** — Extract patterns from existing code
+- **"critique"** — Critique build for craft, then rebuild what defaulted


### PR DESCRIPTION
Port the full Claude Code skill system to Cursor's .cursor/rules/ format:
- interface-design.mdc: Core skill (alwaysApply) with full design philosophy
- interface-design-principles.mdc: Craft principles (auto-attached to UI files)
- interface-design-init.mdc: Build UI workflow (agent-requested)
- interface-design-critique.mdc: Critique workflow (agent-requested)
- interface-design-audit.mdc: Audit workflow (agent-requested)
- interface-design-extract.mdc: Extract patterns workflow (agent-requested)
- interface-design-status.mdc: Status display (agent-requested)
- interface-design-validation.mdc: Memory management (agent-requested)
- interface-design-examples.mdc: Craft examples (agent-requested)
- interface-design-templates.mdc: System templates and references (agent-requested)

https://claude.ai/code/session_0155Kc1rSiwvLS6adUqZKS5j